### PR TITLE
fix: typo of medium

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -153,11 +153,11 @@ ${host}/_/${username}?${queryString}
      通过指定这一属性，自动计算周的数量 和 最佳的 ios 小组件，可用值为：
       <ul>
         <li><code>small</code></li>
-        <li><code>midium</code></li>
+        <li><code>medium</code></li>
         <li><code>large</code></li>
       </ul>
     </td>
-    <td><code>midium</code></td>
+    <td><code>medium</code></td>
   </tr>
 
   <tr>

--- a/README.md
+++ b/README.md
@@ -149,11 +149,11 @@ ${host}/_/${username}?${queryString}
       Automatically calculate the number of weeks and size needed for the ios widget by specifying this property, avaiable values:
       <ul>
         <li><code>small</code></li>
-        <li><code>midium</code></li>
+        <li><code>medium</code></li>
         <li><code>large</code></li>
       </ul>
     </td>
-    <td><code>midium</code></td>
+    <td><code>medium</code></td>
   </tr>
 
   <tr>
@@ -428,7 +428,7 @@ let [chart, widgetSize, theme, weeks] = (args.widgetParameter || "")
   .split(",")
   .map((v) => v.trim());
 chart = chart || "calendar";
-widgetSize = widgetSize || "midium";
+widgetSize = widgetSize || "medium";
 theme = theme || "green";
 const darkMode = Device.isUsingDarkAppearance();
 let url = `https://ssr-contributions-svg.vercel.app/_/CatsJuice?format=jpeg&quality=2&theme=${theme}&widget_size=${widgetSize}&chart=${chart}&dark=${darkMode}`;

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -61,7 +61,7 @@ export class AppService {
         _config.weeks ||
         {
           [WidgetSize.LARGE]: 40,
-          [WidgetSize.MIDIUM]: 16,
+          [WidgetSize.MEDIUM]: 16,
           [WidgetSize.SMALL]: 7,
         }[_config.widget_size] ||
         16,

--- a/src/dto/base/widget-size.dto.ts
+++ b/src/dto/base/widget-size.dto.ts
@@ -1,13 +1,19 @@
+import { Transform } from 'class-transformer';
+import { decorate } from 'ts-mixer';
+
 export enum WidgetSize {
   SMALL = 'small',
-  MIDIUM = 'midium',
+  MEDIUM = 'medium',
   LARGE = 'large',
 }
 
 export class WidgetSizeDto {
   /**
    * ios Widget size, Affect weeks
-   * @default {"midium"}
+   * @default {"medium"}
    */
+  @decorate(
+    Transform(({ value }) => (value === 'midium' ? WidgetSize.MEDIUM : value)),
+  )
   widget_size?: WidgetSize;
 }

--- a/src/libs/config.constant.ts
+++ b/src/libs/config.constant.ts
@@ -342,7 +342,7 @@ export const config: ConfigItem[] = [
     },
     optioins: [
       { value: WidgetSize.SMALL, label: { en: 'Small', zh: '小' } },
-      { value: WidgetSize.MIDIUM, label: { en: 'Midium', zh: '中' } },
+      { value: WidgetSize.MEDIUM, label: { en: 'Medium', zh: '中' } },
       { value: WidgetSize.SMALL, label: { en: 'Large', zh: '大' } },
     ],
   },

--- a/src/types/chart-config.interface.ts
+++ b/src/types/chart-config.interface.ts
@@ -7,7 +7,7 @@ export interface BaseChartConfig {
 }
 
 export const defaultCalendarChartConfig: CalendarChartConfig = {
-  widget_size: WidgetSize.MIDIUM,
+  widget_size: WidgetSize.MEDIUM,
   quality: 1,
   tz: 'Asia/Shanghai',
 };
@@ -18,7 +18,7 @@ export interface CalendarChartConfig extends BaseChartConfig {
 }
 
 export const defaultCalenderChart3dConfig: CalendarChart3DConfig = {
-  widget_size: WidgetSize.MIDIUM,
+  widget_size: WidgetSize.MEDIUM,
   quality: 1,
   scale: 2,
   gap: 1.2,


### PR DESCRIPTION
Fix all typos "medium" in enum, readme and dtos. And apply forced conversion of `midium` to `medium` in query pipe.
fix #40