### PR TITLE
feat: add configurable chart background

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -131,11 +131,11 @@ ${host}/_/${username}?${queryString}
         </li>
         <li>
           <code>png</code>
-          <span>: 返回 png 格式的文件(透明背景)</span>
+          <span>: 返回 png 格式的文件（默认透明背景，传入 <code>backgroundColor</code> 后会铺底）</span>
         </li>
         <li>
           <code>jpeg</code>
-          <span>: 返回 jpeg 格式的文件(白色背景)</span>
+          <span>: 返回 jpeg 格式的文件（默认浅色/深色背景，可通过 <code>backgroundColor</code> 覆盖）</span>
         </li>
       </ul>
     </td>
@@ -219,6 +219,18 @@ ${host}/_/${username}?${queryString}
     <td>
       <code>false</code>
     </td>
+  </tr>
+
+  <tr>
+    <td>backgroundColor</td>
+    <td><code>string</code></td>
+    <td>
+      可选的页面或位图背景色。支持带或不带 <code>#</code> 的十六进制颜色，也保留 <code>rgba(...)</code> 这类 CSS 颜色字符串。
+      <br />
+      会覆盖 <code>html</code> 和 <code>jpeg</code> 的默认浅色/深色背景。
+      传入后 <code>png</code> 也会在导出时铺上该背景色。
+    </td>
+    <td><code>undefined</code></td>
   </tr>
 
 </table>
@@ -449,7 +461,7 @@ Enable animation by passing <code>animation</code> property, available values:
 
 ## 暗黑模式
 
-实际上，图表的显示由主题（ `theme` ）决定，而主题会被颜色（ `colors` ）属性覆盖。在这里启用暗黑模式，影响的是**内置主题的配色**和输出 `jpeg` 或 `html` 时的背景颜色，而其他输出格式下，背景都是透明的，暗黑模式下的主题色可参考 [主题](#主题)
+实际上，图表的显示由主题（ `theme` ）决定，而主题会被颜色（ `colors` ）属性覆盖。在这里启用暗黑模式，影响的是**内置主题的配色**以及输出 `jpeg` 或 `html` 时的默认背景颜色。你可以用 `backgroundColor` 显式覆盖这个默认值。其他情况下背景保持透明，除非你主动传入 `backgroundColor`。暗黑模式下的主题色可参考 [主题](#主题)
 
 ## 图表
 

--- a/README.md
+++ b/README.md
@@ -129,11 +129,11 @@ ${host}/_/${username}?${queryString}
         </li>
         <li>
           <code>png</code>
-          <span>: return a png file(transparent background)</span>
+          <span>: return a png file(transparent background unless <code>backgroundColor</code> is provided)</span>
         </li>
         <li>
           <code>jpeg</code>
-          <span>: return a jpg file(white background)</span>
+          <span>: return a jpg file(light or dark default background, configurable via <code>backgroundColor</code>)</span>
         </li>
       </ul>
     </td>
@@ -217,6 +217,18 @@ ${host}/_/${username}?${queryString}
     <td>
       <code>false</code>
     </td>
+  </tr>
+
+  <tr>
+    <td>backgroundColor</td>
+    <td><code>string</code></td>
+    <td>
+      Optional page or raster background color. Supports hex values with or without <code>#</code>, and also preserves CSS color strings such as <code>rgba(...)</code>.
+      <br />
+      Overrides the default light or dark background for <code>html</code> and <code>jpeg</code>.
+      When provided, <code>png</code> will also be flattened onto this background.
+    </td>
+    <td><code>undefined</code></td>
   </tr>
 
 </table>
@@ -447,7 +459,7 @@ Enable animation by passing <code>animation</code> property, available values:
 
 ## DarkMode
 
-In fact, the display of the chart is determined by the `theme`, which is overridden by the `color` property. Enabling dark mode here affects **the display of the built-in theme** and the **background color** when outputting `jpeg` or `html`, while the background is `transparent` in all other output formats. For more details, see [Themes](#themes)
+In fact, the display of the chart is determined by the `theme`, which is overridden by the `color` property. Enabling dark mode here affects **the display of the built-in theme** and the default **background color** when outputting `jpeg` or `html`. You can override that default with `backgroundColor`. In all other cases, the background remains `transparent` unless you explicitly set `backgroundColor`. For more details, see [Themes](#themes)
 
 ## Charts
 

--- a/playground/src/components/Preset/index.vue
+++ b/playground/src/components/Preset/index.vue
@@ -16,6 +16,7 @@ type ResolvedPresetConfig = PresetConfig & {
   colors?: string;
   strokeWidth?: number;
   strokeColor?: string;
+  backgroundColor?: string;
 };
 
 const presets = computed(() => {
@@ -26,6 +27,7 @@ const presets = computed(() => {
         dark: activeAppearance.value.dark,
         strokeWidth: activeAppearance.value.strokeWidth,
         strokeColor: activeAppearance.value.strokeColor,
+        backgroundColor: activeAppearance.value.backgroundColor,
         ...(activeAppearance.value.colors
           ? {
               colors: activeAppearance.value.colors,

--- a/playground/src/hooks/useConfig.ts
+++ b/playground/src/hooks/useConfig.ts
@@ -241,6 +241,7 @@ const activeAppearance = computed(() => ({
   colors: state.value.colors ? `${state.value.colors}` : '',
   strokeWidth: state.value.strokeWidth,
   strokeColor: state.value.strokeColor,
+  backgroundColor: state.value.backgroundColor,
 }));
 
 const requestUsername = computed(() => `${username.value || ''}`.trim());
@@ -261,6 +262,7 @@ const themePreviewConfig = computed(() => ({
   foregroundColor: state.value.foregroundColor,
   strokeWidth: state.value.strokeWidth,
   strokeColor: state.value.strokeColor,
+  backgroundColor: state.value.backgroundColor,
   flatten: state.value.flatten,
 }));
 

--- a/shared/render-core/config.ts
+++ b/shared/render-core/config.ts
@@ -11,6 +11,7 @@ export interface BaseChartConfig {
   quality?: number;
   dark?: boolean;
   tz?: string;
+  backgroundColor?: string;
 }
 
 export interface CalendarChartConfig extends BaseChartConfig {

--- a/shared/render-core/normalize.ts
+++ b/shared/render-core/normalize.ts
@@ -41,6 +41,7 @@ export type NormalizedRenderContributionConfig =
     foregroundColor: string;
     strokeWidth?: number;
     strokeColor: string;
+    backgroundColor: string;
   };
 
 function normalizeColor(color: string) {
@@ -154,6 +155,10 @@ export function normalizeRenderConfig(
     strokeColor:
       typeof input.strokeColor === 'string'
         ? normalizeColor(input.strokeColor)
+        : '',
+    backgroundColor:
+      typeof input.backgroundColor === 'string'
+        ? normalizeColor(input.backgroundColor)
         : '',
   };
 }

--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -28,6 +28,20 @@ describe('AppController', () => {
     );
   });
 
+  it('should expose backgroundColor as a general output option', () => {
+    const backgroundColorConfig = config.find(
+      (item) => item.key === 'backgroundColor',
+    );
+
+    expect(backgroundColorConfig).toMatchObject({
+      type: 'color',
+      panel: {
+        tab: { key: 'general' },
+        group: { key: 'general-output' },
+      },
+    });
+  });
+
   it('should expose panel metadata and the random theme option', () => {
     const themeConfig = config.find((item) => item.key === 'theme');
     const chartConfig = config.find((item) => item.key === 'chart');

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -34,7 +34,7 @@ export class AppController {
     console.log('Request svg/:username, username = ', username);
     console.log(JSON.stringify(query));
 
-    const svgCode = await this.appService.generateChartSvgCode(
+    const { svgCode, config } = await this.appService.generateChartSvgCode(
       req.user, // user was recorded in UsernameExistsGuard
       query,
     );
@@ -43,7 +43,8 @@ export class AppController {
       format: query.format,
       quality: query.quality,
       filename: `${username}_${Date.now()}`,
-      dark: query.dark,
+      dark: config.dark,
+      backgroundColor: config.backgroundColor,
     });
   }
 

--- a/src/app.service.spec.ts
+++ b/src/app.service.spec.ts
@@ -1,0 +1,99 @@
+import { ConfigService } from '@nestjs/config';
+
+import { AppService } from './app.service';
+import { OutputFormat } from './dto/base/output-format.dto';
+import * as svg2imageModule from './utils/svg2image';
+import * as generateHtmlModule from './utils/generate-html';
+
+describe('AppService', () => {
+  const createResponse = () =>
+    ({
+      header: jest.fn().mockReturnThis(),
+      send: jest.fn(),
+    }) as any;
+
+  const createService = () =>
+    new AppService(
+      new ConfigService({
+        theme: {
+          bg: {
+            dark: '#22272e',
+            light: '#ffffff',
+          },
+        },
+      }),
+    );
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should use the custom background color for html and jpeg responses', async () => {
+    const service = createService();
+    const res = createResponse();
+    const imageBuffer = Buffer.from('image');
+
+    const generateHtml = jest
+      .spyOn(generateHtmlModule, 'generateHtml')
+      .mockReturnValue('<html></html>');
+    const svgCode2image = jest
+      .spyOn(svg2imageModule, 'svgCode2image')
+      .mockResolvedValue(imageBuffer);
+
+    await service.resolveResponseByFormat(res, '<svg />', {
+      format: OutputFormat.HTML,
+      filename: 'chart',
+      dark: false,
+      backgroundColor: '#111827',
+    });
+    await service.resolveResponseByFormat(res, '<svg />', {
+      format: OutputFormat.JPEG,
+      filename: 'chart',
+      dark: false,
+      backgroundColor: '#111827',
+    });
+
+    expect(generateHtml).toHaveBeenCalledWith('<svg />', 'chart', '#111827');
+    expect(svgCode2image).toHaveBeenCalledWith(
+      '<svg />',
+      'jpeg',
+      1,
+      '#111827',
+    );
+  });
+
+  it('should keep png transparent unless a custom background color is provided', async () => {
+    const service = createService();
+    const imageBuffer = Buffer.from('image');
+    const svgCode2image = jest
+      .spyOn(svg2imageModule, 'svgCode2image')
+      .mockResolvedValue(imageBuffer);
+
+    await service.resolveResponseByFormat(createResponse(), '<svg />', {
+      format: OutputFormat.PNG,
+      filename: 'chart',
+      dark: true,
+    });
+    await service.resolveResponseByFormat(createResponse(), '<svg />', {
+      format: OutputFormat.PNG,
+      filename: 'chart',
+      dark: true,
+      backgroundColor: '#0f172a',
+    });
+
+    expect(svgCode2image).toHaveBeenNthCalledWith(
+      1,
+      '<svg />',
+      'png',
+      1,
+      undefined,
+    );
+    expect(svgCode2image).toHaveBeenNthCalledWith(
+      2,
+      '<svg />',
+      'png',
+      1,
+      '#0f172a',
+    );
+  });
+});

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -10,7 +10,10 @@ import { GithubUser } from './types/contribution.interface';
 import { themes } from './utils/get-theme';
 import { ConfigSvgQueryDto } from './dto/config-svg.query.dto';
 import { SvgResponseResolverOptions } from './types/svg-res-resolver-opt.interface';
-import { renderContributionSvg } from '../shared/render-core/render';
+import {
+  normalizeRenderConfig,
+  renderContributionSvg,
+} from '../shared/render-core';
 
 @Injectable()
 export class AppService {
@@ -33,19 +36,23 @@ export class AppService {
     user: GithubUser,
     _config: ConfigSvgQueryDto,
   ) {
-    const config = { ..._config };
+    const config = normalizeRenderConfig(_config);
+    const renderConfig = { ...config };
     if ([OutputFormat.PNG, OutputFormat.JPEG].includes(_config.format)) {
-      delete config.animation;
+      delete renderConfig.animation;
     }
 
-    const svgStr = await renderContributionSvg(user, config);
+    const svgStr = await renderContributionSvg(user, renderConfig);
     if (!svgStr) {
       throw new BadRequestException(
-        'Unimplemented chart type: ' + config.chart,
+        'Unimplemented chart type: ' + renderConfig.chart,
       );
     }
 
-    return svgStr;
+    return {
+      svgCode: svgStr,
+      config,
+    };
   }
 
   /**
@@ -61,14 +68,17 @@ export class AppService {
     svgCode: string,
     options: SvgResponseResolverOptions = {},
   ) {
-    const { format, quality, dark } = options;
+    const { format, quality, dark, backgroundColor } = options;
     const filename = options.filename || `${Date.now()}`;
 
     const roundQuality = Math.min(
       10,
       Math.max(0.1, parseFloat(`${quality}`) || 1),
     );
-    const bg = this._cfgSrv.get(`theme.bg.${dark ? 'dark' : 'light'}`);
+    const defaultBackgroundColor = this._cfgSrv.get(
+      `theme.bg.${dark ? 'dark' : 'light'}`,
+    );
+    const resolvedBackgroundColor = backgroundColor || defaultBackgroundColor;
     if (format === OutputFormat.SVG) {
       res.header('Content-Type', 'image/svg+xml; charset=utf-8');
       // res.header('Content-Disposition', `inline; filename=${filename}.svg`);
@@ -78,15 +88,24 @@ export class AppService {
       res.send(svgCode);
     } else if (format === OutputFormat.HTML) {
       res.header('Content-Type', 'text/html;charset=utf-8');
-      res.send(generateHtml(svgCode, filename, bg));
+      res.send(generateHtml(svgCode, filename, resolvedBackgroundColor));
     } else if (format === OutputFormat.PNG) {
       res.header('Content-Type', 'image/png;charset=utf-8');
       res.header('Content-Disposition', `inline; filename=${filename}.png`);
-      res.send(await svgCode2image(svgCode, 'png', roundQuality, bg));
+      res.send(
+        await svgCode2image(svgCode, 'png', roundQuality, backgroundColor),
+      );
     } else if (format === OutputFormat.JPEG) {
       res.header('Content-Type', 'image/jpeg;charset=utf-8');
       res.header('Content-Disposition', `inline; filename=${filename}.jpg`);
-      res.send(await svgCode2image(svgCode, 'jpeg', roundQuality, bg));
+      res.send(
+        await svgCode2image(
+          svgCode,
+          'jpeg',
+          roundQuality,
+          resolvedBackgroundColor,
+        ),
+      );
     } else
       this.resolveResponseByFormat(res, svgCode, {
         ...options,

--- a/src/dto/config-svg.query.dto.ts
+++ b/src/dto/config-svg.query.dto.ts
@@ -190,4 +190,9 @@ export class ConfigSvgQueryDto extends Mixin(
    * @default {"calendar"}
    */
   chart?: ChartTpl;
+
+  @decorate(IsOptional())
+  @decorate(Transform(({ value }) => normalizeColorInput(value)))
+  @decorate(IsString())
+  backgroundColor?: string;
 }

--- a/src/libs/config.constant.ts
+++ b/src/libs/config.constant.ts
@@ -550,4 +550,22 @@ export const config: ConfigItem[] = [
     configGroups.generalTheme,
     30,
   ),
+
+  withPanel(
+    {
+      key: 'backgroundColor',
+      label: {
+        en: 'Background Color',
+        zh: '背景颜色',
+      },
+      type: 'color',
+      description: {
+        en: 'Optional page or raster background color. Overrides the default light or dark background for html and jpeg, and also fills png when provided.',
+        zh: '可选的页面或位图背景色。会覆盖 html 和 jpeg 的默认浅色/深色背景；传入后 png 也会铺上该背景色。',
+      },
+    },
+    configTabs.general,
+    configGroups.generalOutput,
+    30,
+  ),
 ];

--- a/src/types/svg-res-resolver-opt.interface.ts
+++ b/src/types/svg-res-resolver-opt.interface.ts
@@ -5,4 +5,5 @@ export interface SvgResponseResolverOptions {
   quality?: number;
   filename?: string;
   dark?: boolean;
+  backgroundColor?: string;
 }

--- a/src/utils/normalize-render-config.spec.ts
+++ b/src/utils/normalize-render-config.spec.ts
@@ -22,4 +22,22 @@ describe('normalizeRenderConfig', () => {
     expect(config.strokeColor).toBe('white');
     expect(config.foregroundColor).toBe('rgb(255, 0, 170)');
   });
+
+  it('should normalize raw hex background colors like the server dto', () => {
+    const config = normalizeRenderConfig({
+      chart: 'calendar' as any,
+      backgroundColor: '111827',
+    });
+
+    expect(config.backgroundColor).toBe('#111827');
+  });
+
+  it('should preserve non-hex css background colors', () => {
+    const config = normalizeRenderConfig({
+      chart: 'calendar' as any,
+      backgroundColor: 'rgba(17, 24, 39, 0.9)',
+    });
+
+    expect(config.backgroundColor).toBe('rgba(17, 24, 39, 0.9)');
+  });
 });

--- a/src/utils/svg2image.ts
+++ b/src/utils/svg2image.ts
@@ -31,7 +31,7 @@ export const svgCode2image = async (
   svgCode: string,
   format: 'png' | 'jpeg',
   resize = 1,
-  bg = '#fff',
+  bg?: string,
 ) => {
   await configureSharpFontEnvironment();
   const rasterizedSvgCode = await injectSvgTextFontStyle(svgCode);
@@ -41,8 +41,9 @@ export const svgCode2image = async (
     .metadata()
     .then(({ width }) => {
       let ref = sharp(buf);
-      // TODO: add to configuration
-      if (format === 'jpeg') ref = ref.flatten({ background: bg });
+      if (format === 'jpeg' || bg) {
+        ref = ref.flatten({ background: bg || '#fff' });
+      }
       return ref
         .toFormat(format)
         .resize(Math.round(width * resize) * 2)


### PR DESCRIPTION
## Summary
- add a backgroundColor query parameter and expose it in the public config schema and playground
- preserve current defaults for html and jpeg, while allowing png to opt into a filled background when requested
- add service and normalization tests, and document the new behavior in both READMEs

## Testing
- yarn test --runInBand
- yarn build

Closes #4